### PR TITLE
Allow blueprint updates before KG has topic nodes (avoid premature 409)

### DIFF
--- a/services/course-lifecycle/app/api/routers/courses.py
+++ b/services/course-lifecycle/app/api/routers/courses.py
@@ -31,10 +31,12 @@ router = APIRouter()
 def has_initialized_kg(course_graph: Dict[str, Any] | None) -> bool:
     if not course_graph:
         return False
+    if not isinstance(course_graph, dict):
+        return False
 
     children = course_graph.get("children") or []
     for module in children:
-        if module.get("children"):
+        if isinstance(module, dict) and module.get("children"):
             return True
 
     return False
@@ -661,6 +663,5 @@ The AI Architect is requested to generate detailed slide content for the followi
 4. Generate strict JSON output for slides.
 """
     return {"prompt_text": prompt}
-
 
 

--- a/services/course-lifecycle/app/api/routers/courses.py
+++ b/services/course-lifecycle/app/api/routers/courses.py
@@ -28,6 +28,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+def has_initialized_kg(course_graph: Dict[str, Any] | None) -> bool:
+    if not course_graph:
+        return False
+
+    children = course_graph.get("children") or []
+    for module in children:
+        if module.get("children"):
+            return True
+
+    return False
+
 # --- Helper Pydantic Models ---
 class TopicJobResponse(BaseModel):
     id: int
@@ -119,7 +130,7 @@ async def update_blueprint(course_id: int, req: BlueprintUpdateRequest, db: Sess
         raise HTTPException(status_code=404, detail="Course not found")
         
     # LOCK: Prevent mutation if KG exists
-    if course.course_graph and course.course_graph.get("children"):
+    if has_initialized_kg(course.course_graph):
         logger.warning(f"Blocked blueprint update for Course {course_id}: KG already initialized.")
         raise HTTPException(
             status_code=409, 
@@ -156,7 +167,7 @@ async def trigger_generation_v2(course_id: int, req: GenerationRequest, db: Sess
         raise HTTPException(status_code=404, detail="Course not found")
         
     # Conditional Blueprint Update: Only if KG not valid
-    if not (course.course_graph and course.course_graph.get("children")):
+    if not has_initialized_kg(course.course_graph):
          course.blueprint = req.blueprint
     else:
          logger.info(f"Skipping blueprint update for Course {course_id} in generate_v2: KG exists.")
@@ -650,7 +661,6 @@ The AI Architect is requested to generate detailed slide content for the followi
 4. Generate strict JSON output for slides.
 """
     return {"prompt_text": prompt}
-
 
 
 


### PR DESCRIPTION
### Motivation
- The blueprint update endpoint was returning `409` as soon as a course had a non-empty `course_graph` even if that graph contained only empty module shells.  
- The lock should only apply when the KG has actual topic children (real content), otherwise Step1 blueprint updates must be allowed.  
- This change prevents the frontend Step1 flow from being blocked when the KG is present but contains no topics.  
- Code locations inspected: `services/course-lifecycle/app/api/routers/courses.py` (helper and uses added).  

### Description
- Added a helper `has_initialized_kg(course_graph: Dict[str, Any] | None) -> bool` to detect a KG as initialized only when modules contain `children` (topic nodes) at `services/course-lifecycle/app/api/routers/courses.py` (approx `L31-L40`).  
- Replaced the previous `course.course_graph and course.course_graph.get("children")` checks with `has_initialized_kg(...)` in the blueprint update endpoint at `.../courses.py` (approx `L126-L143`) to avoid premature locking.  
- Applied the same helper in the `generate_v2` path to conditionally sync the blueprint only when the KG is truly initialized (approx `L162-L174`).  
- Minimal, focused change — no schema or DB migrations required.  

### Testing
- Ran `docker compose build` in CI environment (local runner) but build could not be executed because `docker` is not available in this environment (failed).  
- Ran the repository test script `./test_system.sh` which reported the Course Lifecycle Service is not responding (failed).  
- Verified code compiles/opens and committed the change locally (`git commit`) and confirmed file `services/course-lifecycle/app/api/routers/courses.py` was updated.  
- No additional automated tests were present or executed successfully in this environment due to missing Docker/service runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2f552b288322ab2ff7139bcd8b7a)